### PR TITLE
Update windows crate to 0.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,19 @@ keywords = ["Windows", "WinSDK", "Audio", "COM"]
 categories = ["api-bindings", "os::windows-apis"]
 
 [dependencies.windows]
-version = "0.52"
+version = "0.61"
 features = [
     "Win32_Foundation",
     "Win32_Media_Audio",
     "Win32_UI_Shell_PropertiesSystem",
     "Win32_System_Com_StructuredStorage",
     "Win32_System_Variant",
-    "Devices_Custom"
+    "Devices_Custom",
 ]
 
 [dev-dependencies.windows]
-version = "0.52"
-features = [
-    "Win32_Devices_FunctionDiscovery",
-]
+version = "0.61"
+features = ["Win32_Devices_FunctionDiscovery"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Readme.md
+++ b/Readme.md
@@ -12,46 +12,9 @@ More additional resources:
 
 **Important**: It is possible I made a mistake during the port or messed up some type. Take everything with a grain of salt.
 
-## Example
+## Examples
 
-```rust
-use windows::core::{PCWSTR, Result};
-use windows::Win32::Devices::FunctionDiscovery::PKEY_Device_FriendlyName;
-use windows::Win32::Media::Audio::{DEVICE_STATE_ACTIVE, eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator};
-use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance, COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize, STGM_READ};
-use com_policy_config::{IPolicyConfig, PolicyConfigClient};
-
-fn main() -> Result<()>{
-
-    unsafe {
-        CoInitializeEx(None, COINIT_MULTITHREADED)?;
-
-        let enumerator: IMMDeviceEnumerator = CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)?;
-
-        println!("All Devices:");
-        let device_collection = enumerator.EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE)?;
-        for i in 0..device_collection.GetCount()? {
-            let device = device_collection.Item(i)?;
-            let property_store = device.OpenPropertyStore(STGM_READ)?;
-            let name = property_store.GetValue(&PKEY_Device_FriendlyName)?;
-            println!("  {}", name.Anonymous.Anonymous.Anonymous.pwszVal.display());
-        }
-
-        let selected_device = device_collection.Item(0)?;
-        let property_store = selected_device.OpenPropertyStore(STGM_READ)?;
-        let name = property_store.GetValue(&PKEY_Device_FriendlyName)?;
-        println!("Selected Device: {}", name.Anonymous.Anonymous.Anonymous.pwszVal.display());
-
-        let device_id = PCWSTR(selected_device.GetId()?.0);
-        let policy_config: IPolicyConfig = CoCreateInstance(&PolicyConfigClient, None, CLSCTX_ALL)?;
-        policy_config.SetDefaultEndpoint(&device_id, eConsole)?;
-
-        CoUninitialize();
-    }
-
-    Ok(())
-}
-```
+Check out the [examples](./examples) directory for usage.
 
 
 ## License

--- a/examples/change_default_device.rs
+++ b/examples/change_default_device.rs
@@ -1,15 +1,19 @@
-use windows::core::{PCWSTR, Result};
-use windows::Win32::Devices::FunctionDiscovery::PKEY_Device_FriendlyName;
-use windows::Win32::Media::Audio::{DEVICE_STATE_ACTIVE, eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator};
-use windows::Win32::System::Com::{CLSCTX_ALL, CoCreateInstance, COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize, STGM_READ};
 use com_policy_config::{IPolicyConfig, PolicyConfigClient};
+use windows::core::{Result, PCWSTR};
+use windows::Win32::Devices::FunctionDiscovery::PKEY_Device_FriendlyName;
+use windows::Win32::Media::Audio::{
+    eConsole, eRender, IMMDeviceEnumerator, MMDeviceEnumerator, DEVICE_STATE_ACTIVE,
+};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_MULTITHREADED, STGM_READ,
+};
 
-fn main() -> Result<()>{
-
+fn main() -> Result<()> {
     unsafe {
-        CoInitializeEx(None, COINIT_MULTITHREADED)?;
+        CoInitializeEx(None, COINIT_MULTITHREADED).ok()?;
 
-        let enumerator: IMMDeviceEnumerator = CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)?;
+        let enumerator: IMMDeviceEnumerator =
+            CoCreateInstance(&MMDeviceEnumerator, None, CLSCTX_ALL)?;
 
         println!("All Devices:");
         let device_collection = enumerator.EnumAudioEndpoints(eRender, DEVICE_STATE_ACTIVE)?;
@@ -23,13 +27,14 @@ fn main() -> Result<()>{
         let selected_device = device_collection.Item(0)?;
         let property_store = selected_device.OpenPropertyStore(STGM_READ)?;
         let name = property_store.GetValue(&PKEY_Device_FriendlyName)?;
-        println!("Selected Device: {}", name.Anonymous.Anonymous.Anonymous.pwszVal.display());
+        println!(
+            "Selected Device: {}",
+            name.Anonymous.Anonymous.Anonymous.pwszVal.display()
+        );
 
         let device_id = PCWSTR(selected_device.GetId()?.0);
         let policy_config: IPolicyConfig = CoCreateInstance(&PolicyConfigClient, None, CLSCTX_ALL)?;
         policy_config.SetDefaultEndpoint(device_id, eConsole)?;
-
-
     }
 
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@
 
 use std::ffi::c_void;
 use std::mem::zeroed;
-use windows::core::{GUID, Interface, IUnknown, Result, PCWSTR, HRESULT, ComInterface, IntoParam, CanInto};
+use windows::core::imp::CanInto;
+use windows::core::{IUnknown, Interface, Param, Result, BOOL, GUID, HRESULT, PCWSTR};
 use windows::Devices::Custom::DeviceSharingMode;
-use windows::Win32::Foundation::BOOL;
+use windows::Win32::Foundation::PROPERTYKEY;
 use windows::Win32::Media::Audio::{ERole, WAVEFORMATEX};
 use windows::Win32::System::Com::StructuredStorage::PROPVARIANT;
-use windows::Win32::UI::Shell::PropertiesSystem::PROPERTYKEY;
 
 pub const PolicyConfigClient: GUID = GUID::from_u128(0x870af99c_171d_4f9e_af0d_e63df40c2bc9);
 
@@ -21,81 +21,220 @@ pub struct IPolicyConfig(IUnknown);
 impl CanInto<IUnknown> for IPolicyConfig {}
 
 impl IPolicyConfig {
-    pub unsafe fn GetMixFormat(&self, device_name: impl IntoParam<PCWSTR>) -> Result<*mut WAVEFORMATEX> {
+    pub unsafe fn GetMixFormat(
+        &self,
+        device_name: impl Param<PCWSTR>,
+    ) -> Result<*mut WAVEFORMATEX> {
         let mut result__ = zeroed::<*mut WAVEFORMATEX>();
-        (Interface::vtable(self).GetMixFormat)(Interface::as_raw(self), device_name.into_param().abi(), &mut result__).from_abi(result__)
+        (Interface::vtable(self).GetMixFormat)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            &mut result__,
+        )
+        .map(|| result__)
     }
 
-    pub unsafe fn GetDeviceFormat(&self, device_name: impl IntoParam<PCWSTR>, default: impl Into<BOOL>) -> Result<*mut WAVEFORMATEX> {
+    pub unsafe fn GetDeviceFormat(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        default: impl Into<BOOL>,
+    ) -> Result<*mut WAVEFORMATEX> {
         let mut result__ = zeroed::<*mut WAVEFORMATEX>();
-        (Interface::vtable(self).GetDeviceFormat)(Interface::as_raw(self), device_name.into_param().abi(), default.into().0, &mut result__).from_abi(result__)
+        (Interface::vtable(self).GetDeviceFormat)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            default.into().0,
+            &mut result__,
+        )
+        .map(|| result__)
     }
 
-    pub unsafe fn ResetDeviceFormat(&self, device_name: impl IntoParam<PCWSTR>) -> Result<()> {
-        (Interface::vtable(self).ResetDeviceFormat)(Interface::as_raw(self), device_name.into_param().abi()).ok()
+    pub unsafe fn ResetDeviceFormat(&self, device_name: impl Param<PCWSTR>) -> Result<()> {
+        (Interface::vtable(self).ResetDeviceFormat)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+        )
+        .ok()
     }
 
-    pub unsafe fn SetDeviceFormat(&self, device_name: impl IntoParam<PCWSTR>, mut endpoint_format: WAVEFORMATEX, mut mix_format: WAVEFORMATEX) -> Result<()> {
-        (Interface::vtable(self).SetDeviceFormat)(Interface::as_raw(self), device_name.into_param().abi(), &mut endpoint_format, &mut mix_format).ok()
+    pub unsafe fn SetDeviceFormat(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        mut endpoint_format: WAVEFORMATEX,
+        mut mix_format: WAVEFORMATEX,
+    ) -> Result<()> {
+        (Interface::vtable(self).SetDeviceFormat)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            &mut endpoint_format,
+            &mut mix_format,
+        )
+        .ok()
     }
 
-    pub unsafe fn GetProcessingPeriod(&self, device_name: impl IntoParam<PCWSTR>, default: impl Into<BOOL>, default_period: *mut i64, min_period: *mut i64) -> Result<()> {
-        (Interface::vtable(self).GetProcessingPeriod)(Interface::as_raw(self), device_name.into_param().abi(), default.into().0, default_period, min_period).ok()
+    pub unsafe fn GetProcessingPeriod(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        default: impl Into<BOOL>,
+        default_period: *mut i64,
+        min_period: *mut i64,
+    ) -> Result<()> {
+        (Interface::vtable(self).GetProcessingPeriod)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            default.into().0,
+            default_period,
+            min_period,
+        )
+        .ok()
     }
 
-    pub unsafe fn SetProcessingPeriod(&self, device_name: impl IntoParam<PCWSTR>, period: *mut i64) -> Result<()> {
-        (Interface::vtable(self).SetProcessingPeriod)(Interface::as_raw(self), device_name.into_param().abi(), period).ok()
+    pub unsafe fn SetProcessingPeriod(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        period: *mut i64,
+    ) -> Result<()> {
+        (Interface::vtable(self).SetProcessingPeriod)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            period,
+        )
+        .ok()
     }
 
-    pub unsafe fn GetShareMode(&self, device_name: impl IntoParam<PCWSTR>) -> Result<DeviceSharingMode> {
+    pub unsafe fn GetShareMode(
+        &self,
+        device_name: impl Param<PCWSTR>,
+    ) -> Result<DeviceSharingMode> {
         let mut result__ = zeroed::<DeviceSharingMode>();
-        (Interface::vtable(self).GetShareMode)(Interface::as_raw(self), device_name.into_param().abi(), &mut result__).from_abi(result__)
+        (Interface::vtable(self).GetShareMode)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            &mut result__,
+        )
+        .map(|| result__)
     }
 
-    pub unsafe fn SetShareMode(&self, device_name: impl IntoParam<PCWSTR>, mut mode: DeviceSharingMode) -> Result<()> {
-        (Interface::vtable(self).SetShareMode)(Interface::as_raw(self), device_name.into_param().abi(), &mut mode).ok()
+    pub unsafe fn SetShareMode(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        mut mode: DeviceSharingMode,
+    ) -> Result<()> {
+        (Interface::vtable(self).SetShareMode)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            &mut mode,
+        )
+        .ok()
     }
 
-    pub unsafe fn GetPropertyValue(&self, device_name: impl IntoParam<PCWSTR>, bFxStore: impl Into<BOOL>, key: *const PROPERTYKEY) -> Result<PROPVARIANT> {
+    pub unsafe fn GetPropertyValue(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        bFxStore: impl Into<BOOL>,
+        key: *const PROPERTYKEY,
+    ) -> Result<PROPVARIANT> {
         let mut result__ = zeroed::<PROPVARIANT>();
-        (Interface::vtable(self).GetPropertyValue)(Interface::as_raw(self), device_name.into_param().abi(), bFxStore.into().0, key, &mut result__).from_abi(result__)
+        (Interface::vtable(self).GetPropertyValue)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            bFxStore.into().0,
+            key,
+            &mut result__,
+        )
+        .map(|| result__)
     }
 
-    pub unsafe fn SetPropertyValue(&self, device_name: impl IntoParam<PCWSTR>, bFxStore: impl Into<BOOL>, key: *const PROPERTYKEY, propvar: *mut PROPVARIANT) -> Result<()> {
-        (Interface::vtable(self).SetPropertyValue)(Interface::as_raw(self), device_name.into_param().abi(), bFxStore.into().0, key, propvar).ok()
+    pub unsafe fn SetPropertyValue(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        bFxStore: impl Into<BOOL>,
+        key: *const PROPERTYKEY,
+        propvar: *mut PROPVARIANT,
+    ) -> Result<()> {
+        (Interface::vtable(self).SetPropertyValue)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            bFxStore.into().0,
+            key,
+            propvar,
+        )
+        .ok()
     }
 
-    pub unsafe fn SetDefaultEndpoint(&self, device_name: impl IntoParam<PCWSTR>, role: ERole) -> Result<()> {
-        (Interface::vtable(self).SetDefaultEndpoint)(Interface::as_raw(self), device_name.into_param().abi(), role).ok()
+    pub unsafe fn SetDefaultEndpoint(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        role: ERole,
+    ) -> Result<()> {
+        (Interface::vtable(self).SetDefaultEndpoint)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            role,
+        )
+        .ok()
     }
 
-    pub unsafe fn SetEndpointVisibility(&self, device_name: impl IntoParam<PCWSTR>, visible: impl Into<BOOL>) -> Result<()> {
-        (Interface::vtable(self).SetEndpointVisibility)(Interface::as_raw(self), device_name.into_param().abi(), visible.into().0).ok()
+    pub unsafe fn SetEndpointVisibility(
+        &self,
+        device_name: impl Param<PCWSTR>,
+        visible: impl Into<BOOL>,
+    ) -> Result<()> {
+        (Interface::vtable(self).SetEndpointVisibility)(
+            Interface::as_raw(self),
+            device_name.param().abi(),
+            visible.into().0,
+        )
+        .ok()
     }
-}
-
-unsafe impl ComInterface for IPolicyConfig {
-    const IID: GUID = GUID::from_u128(0xf8679f50_850a_41cf_9c72_430f290290c8);
 }
 
 unsafe impl Interface for IPolicyConfig {
     type Vtable = IPolicyConfig_Vtbl;
+    const IID: GUID = GUID::from_u128(0xf8679f50_850a_41cf_9c72_430f290290c8);
 }
 
 #[repr(C)]
 #[doc(hidden)]
 pub struct IPolicyConfig_Vtbl {
     pub base__: ::windows::core::IUnknown_Vtbl,
-    pub GetMixFormat: unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut *mut WAVEFORMATEX) -> HRESULT,
-    pub GetDeviceFormat: unsafe extern "system" fn(this: *mut c_void, PCWSTR, i32, *mut *mut WAVEFORMATEX) -> HRESULT,
+    pub GetMixFormat:
+        unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut *mut WAVEFORMATEX) -> HRESULT,
+    pub GetDeviceFormat: unsafe extern "system" fn(
+        this: *mut c_void,
+        PCWSTR,
+        i32,
+        *mut *mut WAVEFORMATEX,
+    ) -> HRESULT,
     pub ResetDeviceFormat: unsafe extern "system" fn(this: *mut c_void, PCWSTR) -> HRESULT,
-    pub SetDeviceFormat: unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut WAVEFORMATEX, *mut WAVEFORMATEX) -> HRESULT,
-    pub GetProcessingPeriod: unsafe extern "system" fn(this: *mut c_void, PCWSTR, i32, *mut i64, *mut i64) -> HRESULT,
-    pub SetProcessingPeriod: unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut i64) -> HRESULT,
-    pub GetShareMode: unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut DeviceSharingMode) -> HRESULT,
-    pub SetShareMode: unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut DeviceSharingMode) -> HRESULT,
-    pub GetPropertyValue: unsafe extern "system" fn(this: *mut c_void, PCWSTR, i32, *const PROPERTYKEY, *mut PROPVARIANT) -> HRESULT,
-    pub SetPropertyValue: unsafe extern "system" fn(this: *mut c_void, PCWSTR, i32, *const PROPERTYKEY, *mut PROPVARIANT) -> HRESULT,
+    pub SetDeviceFormat: unsafe extern "system" fn(
+        this: *mut c_void,
+        PCWSTR,
+        *mut WAVEFORMATEX,
+        *mut WAVEFORMATEX,
+    ) -> HRESULT,
+    pub GetProcessingPeriod:
+        unsafe extern "system" fn(this: *mut c_void, PCWSTR, i32, *mut i64, *mut i64) -> HRESULT,
+    pub SetProcessingPeriod:
+        unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut i64) -> HRESULT,
+    pub GetShareMode:
+        unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut DeviceSharingMode) -> HRESULT,
+    pub SetShareMode:
+        unsafe extern "system" fn(this: *mut c_void, PCWSTR, *mut DeviceSharingMode) -> HRESULT,
+    pub GetPropertyValue: unsafe extern "system" fn(
+        this: *mut c_void,
+        PCWSTR,
+        i32,
+        *const PROPERTYKEY,
+        *mut PROPVARIANT,
+    ) -> HRESULT,
+    pub SetPropertyValue: unsafe extern "system" fn(
+        this: *mut c_void,
+        PCWSTR,
+        i32,
+        *const PROPERTYKEY,
+        *mut PROPVARIANT,
+    ) -> HRESULT,
     pub SetDefaultEndpoint: unsafe extern "system" fn(this: *mut c_void, PCWSTR, ERole) -> HRESULT,
-    pub SetEndpointVisibility: unsafe extern "system" fn(this: *mut c_void, PCWSTR, i32) -> HRESULT
+    pub SetEndpointVisibility: unsafe extern "system" fn(this: *mut c_void, PCWSTR, i32) -> HRESULT,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ unsafe impl Interface for IPolicyConfig {
 
 #[repr(C)]
 #[doc(hidden)]
+#[allow(non_camel_case_types)]
 pub struct IPolicyConfig_Vtbl {
     pub base__: ::windows::core::IUnknown_Vtbl,
     pub GetMixFormat:


### PR DESCRIPTION
This library has been a lifesaver in my project, but the old `windows` crate version was causing version conflicts with other libraries in my project. So I ended up updating it to 0.61 to fix that. I'm pretty new to rust, so let me know if I messed anything up.
  
- Update `windows` crate from 0.52 to 0.61
- Remove example code from README, redirect to examples directory (to avoid having to update it in multiple places)
- Fix non-camel-case warning on `IPolicyConfig_Vtbl` struct